### PR TITLE
Move supports for Amasty Giftcard to magento2-modules-support

### DIFF
--- a/Helper/Amasty/GiftCard.php
+++ b/Helper/Amasty/GiftCard.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Helper\Amasty;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+
+/**
+ * Boltpay Log helper
+ *
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class GiftCard extends AbstractHelper
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @param Context $context
+     * @param BoltLogger $boltLogger
+     * @param ConfigHelper $configHelper
+     */
+    public function __construct(
+        Context $context,
+        Bugsnag $bugsnagHelper,
+        ResourceConnection $resourceConnection
+    ) {
+        parent::__construct($context);
+        $this->bugsnagHelper = $bugsnagHelper;
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * @param Quote $source
+     * @param Quote $destination
+     */
+    public function replicateQuoteData(
+        $source,
+        $destination
+    ) {
+        if ($source->getId() == $destination->getId()) {
+            return;
+        }
+        try {
+            $connection = $this->resourceConnection->getConnection();
+            $connection->beginTransaction();
+            $giftCardTable = $this->resourceConnection->getTableName('amasty_amgiftcard_quote');
+
+            // Clear previously applied gift cart codes from the immutable quote
+            $sql = "DELETE FROM {$giftCardTable} WHERE quote_id = :destination_quote_id";
+            $connection->query($sql, ['destination_quote_id' => $destination->getId()]);
+
+            // Copy all gift cart codes applied to the parent quote to the immutable quote
+            $sql = "INSERT INTO {$giftCardTable} (quote_id, code_id, account_id, base_gift_amount, code)
+                        SELECT :destination_quote_id, code_id, account_id, base_gift_amount, code
+                        FROM {$giftCardTable} WHERE quote_id = :source_quote_id";
+
+            $connection->query(
+                $sql,
+                ['destination_quote_id' => $destination->getId(), 'source_quote_id' => $source->getId()]
+            );
+
+            $connection->commit();
+        } catch (\Zend_Db_Statement_Exception $e) {
+            $connection->rollBack();
+            $this->bugsnagHelper->notifyException($e);
+        }
+    }
+}

--- a/Observer/Amasty/GiftCard/ApplyGiftcardObserver.php
+++ b/Observer/Amasty/GiftCard/ApplyGiftcardObserver.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCard;
+
+use Bolt\Boltpay\Model\ThirdParty\FilterInterface;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
+use Bolt\ModulesSupport\Helper\Amasty\GiftCard as ModulesSupportHelper;
+use Magento\Framework\Event\Observer;
+
+class ApplyGiftcardObserver implements FilterInterface
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * @var Decider
+     */
+    private $featureSwitches;
+    
+    /**
+     * @var ModulesSupportHelper
+     */
+    private $modulesSupportHelper;
+    
+    /**
+     * constructor
+     *
+     * @param Bugsnag $bugsnagHelper
+     * @param Decider $featureSwitches
+     * @param ModulesSupportHelper $modulesSupportHelper
+     */
+    public function __construct(
+        Bugsnag $bugsnagHelper,
+        Decider $featureSwitches,
+        ModulesSupportHelper $modulesSupportHelper
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+        $this->featureSwitches = $featureSwitches;
+        $this->modulesSupportHelper = $modulesSupportHelper;
+    }
+
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // Get result
+        $result = $observer->getResult();
+        // Get send classes
+        $sendClasses = $observer->getSendClasses();
+        list ($giftcardManagementFactory) = $sendClasses;
+        // Get extra arguments
+        $code = $observer->getEvent()->getCode();
+        $giftCard = $observer->getEvent()->getGiftCard();
+        $immutableQuote = $observer->getEvent()->getImmutableQuote();
+        $parentQuote = $observer->getEvent()->getParentQuote();
+
+        if (!$giftCard instanceof \Amasty\GiftCard\Model\Account) {
+            return $result;
+        }
+        try {
+            /** Because {@see \Amasty\GiftCard\Model\GiftCardManagement::$codes} shouldn't persist  */
+            $giftcardManagement = $giftcardManagementFactory->create();
+            if (!$giftcardManagement->isCodeAlreadyInQuote($giftCard, $parentQuote->getId())) {
+
+                $giftcardManagement->set($parentQuote->getId(), $code);
+                $this->modulesSupportHelper->replicateQuoteData($parentQuote, $immutableQuote);
+            }
+            return [
+                'status'          => 'success',
+                'discount_code'   => $code,
+                'discount_amount' => abs(
+                    CurrencyUtils::toMinor($giftCard->getCurrentValue(), $parentQuote->getQuoteCurrencyCode())
+                ),
+                'description'     => __('Gift Card (%1)', $code),
+                'discount_type'   => 'fixed_amount',
+            ];
+        } catch (\Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+            return [
+                'status'        => 'failure',
+                'error_message' => $e->getMessage(),
+            ];
+        }
+    }
+}

--- a/Observer/Amasty/GiftCard/BeforeFailedPaymentOrderSaveObserver.php
+++ b/Observer/Amasty/GiftCard/BeforeFailedPaymentOrderSaveObserver.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCard;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class BeforeFailedPaymentOrderSaveObserver implements ObserverInterface
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * constructor
+     *
+     * @param Bugsnag $bugsnagHelper
+     */
+    public function __construct(
+        Bugsnag $bugsnagHelper
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+    }
+
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // Get send classes
+        $sendClasses = $observer->getSendClasses();
+        list ($giftcardQuoteCollectionFactory, $giftcardCodeRepository, $giftcardAccountRepository) = $sendClasses;
+        // Get extra arguments
+        $order = $observer->getEvent()->getOrder();
+
+        try {
+            $giftcardQuotes = $giftcardQuoteCollectionFactory->create()
+                ->getGiftCardsByQuoteId($order->getQuoteId());
+            /** @var \Amasty\GiftCard\Model\Quote $giftcardQuote */
+            foreach ($giftcardQuotes->getItems() as $giftcardQuote) {
+                try {
+                    $giftcardAccount = $giftcardAccountRepository->getById($giftcardQuote->getAccountId());
+                    $giftcardCode = $giftcardCodeRepository->getById($giftcardAccount->getCodeId());
+                    /** @see \Amasty\GiftCard\Model\Code::STATE_UNUSED */
+                    $giftcardCode->setUsed(0);
+                    $giftcardCodeRepository->save($giftcardCode);
+                    $giftcardAccount->setCurrentValue(
+                        (float)($giftcardAccount->getCurrentValue() + $giftcardQuote->getBaseGiftAmount())
+                    );
+                    /** @see \Amasty\GiftCard\Model\Account::STATUS_ACTIVE */
+                    $giftcardAccount->setStatusId(1);
+                    $giftcardAccountRepository->save($giftcardAccount);
+                } catch (\Magento\Framework\Exception\LocalizedException $e) {
+                    $this->bugsnagHelper->notifyException($e);
+                }
+            }
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            //no giftcards applied on order, safe to ignore
+        }
+    }
+}

--- a/Observer/Amasty/GiftCard/ClearExternalDataObserver.php
+++ b/Observer/Amasty/GiftCard/ClearExternalDataObserver.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCard;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class ClearExternalDataObserver implements ObserverInterface
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+    
+    /**
+     * constructor
+     *
+     * @param ResourceConnection $resourceConnection
+     * @param Bugsnag $bugsnagHelper
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        Bugsnag $bugsnagHelper
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+        $this->resourceConnection = $resourceConnection;
+    }
+    
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // Get extra arguments
+        $quote = $observer->getEvent()->getQuote();
+
+        try {
+            $connection = $this->resourceConnection->getConnection();
+            $giftCardTable = $this->resourceConnection->getTableName('amasty_amgiftcard_quote');
+
+            $sql = "DELETE FROM {$giftCardTable} WHERE quote_id = :quote_id";
+            $bind = [
+                'quote_id' => $quote->getId()
+            ];
+
+            $connection->query($sql, $bind);
+        } catch (\Zend_Db_Statement_Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+        }
+    }
+}

--- a/Observer/Amasty/GiftCard/DeleteRedundantDiscountsObserver.php
+++ b/Observer/Amasty/GiftCard/DeleteRedundantDiscountsObserver.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCard;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class DeleteRedundantDiscountsObserver implements ObserverInterface
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+    
+    /**
+     * constructor
+     *
+     * @param ResourceConnection $resourceConnection
+     * @param Bugsnag $bugsnagHelper
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        Bugsnag $bugsnagHelper
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+        $this->resourceConnection = $resourceConnection;
+    }
+    
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // Get extra arguments
+        $parentQuote = $observer->getEvent()->getParentQuote();
+
+        try {
+            $connection = $this->resourceConnection->getConnection();
+            $giftCardTable = $this->resourceConnection->getTableName('amasty_amgiftcard_quote');
+            $quoteTable = $this->resourceConnection->getTableName('quote');
+
+            $sql = "DELETE FROM {$giftCardTable} WHERE quote_id IN 
+                    (SELECT entity_id FROM {$quoteTable} 
+                    WHERE bolt_parent_quote_id = :bolt_parent_quote_id AND entity_id != :entity_id)";
+            
+            $bind = [
+                'bolt_parent_quote_id' => $parentQuote->getBoltParentQuoteId(),
+                'entity_id' => $parentQuote->getBoltParentQuoteId()
+            ];
+
+            $connection->query($sql, $bind);
+        } catch (\Zend_Db_Statement_Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+        }
+    }
+}

--- a/Observer/Amasty/GiftCard/FilterApplyingGiftCardCodeObserver.php
+++ b/Observer/Amasty/GiftCard/FilterApplyingGiftCardCodeObserver.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCard;
+
+use Bolt\Boltpay\Model\ThirdParty\FilterInterface;
+use Magento\Framework\Event\Observer;
+
+class FilterApplyingGiftCardCodeObserver implements FilterInterface
+{
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // Get result
+        $result = $observer->getResult();
+        // Get send classes
+        $sendClasses = $observer->getSendClasses();
+        list ($giftCardManagement) = $sendClasses;
+        // Get extra arguments
+        $giftCard = $observer->getEvent()->getGiftCard();
+        $quote = $observer->getEvent()->getQuote();
+
+        if (!$giftCard instanceof \Amasty\GiftCard\Model\Account) {
+            return $result;
+        }
+        try {
+            $giftCardManagement->set($quote->getId(), $giftCard->getCode());
+            return true;
+        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            return false;
+        }
+    }
+}

--- a/Observer/Amasty/GiftCard/FilterRemovingGiftCardCodeObserver.php
+++ b/Observer/Amasty/GiftCard/FilterRemovingGiftCardCodeObserver.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCard;
+
+use Bolt\Boltpay\Model\ThirdParty\FilterInterface;
+use Magento\Framework\Event\Observer;
+
+class FilterRemovingGiftCardCodeObserver implements FilterInterface
+{
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // Get result
+        $result = $observer->getResult();
+        // Get extra arguments
+        $giftCard = $observer->getEvent()->getGiftCard();
+        $quote = $observer->getEvent()->getQuote();
+
+        if (!$giftCard instanceof \Amasty\GiftCard\Model\Account) {
+            return $result;
+        }
+        try {
+            $giftCardTable = $this->resourceConnection->getTableName('amasty_amgiftcard_quote');
+
+            $sql = "DELETE FROM {$giftCardTable} WHERE code_id = :code_id AND quote_id = :quote_id";
+            $this->resourceConnection->getConnection()->query(
+                $sql,
+                [
+                    'code_id'  => $giftCard->getCodeId(),
+                    'quote_id' => $quote->getId()
+                ]
+            );
+
+            $quote->getShippingAddress()->setCollectShippingRates(true);
+            $quote->setTotalsCollectedFlag(false);
+            $quote->collectTotals();
+            $quote->setDataChanges(true);
+            return true;
+        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            return false;
+        }
+    }
+}

--- a/Observer/Amasty/GiftCard/LoadGiftcardObserver.php
+++ b/Observer/Amasty/GiftCard/LoadGiftcardObserver.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCard;
+
+use Bolt\Boltpay\Model\ThirdParty\FilterInterface;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
+use Magento\Framework\Event\Observer;
+
+class LoadGiftcardObserver implements FilterInterface
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * @var Bolt\Boltpay\Helper\FeatureSwitch\Decider
+     */
+    private $featureSwitches;
+    
+    /**
+     * constructor
+     *
+     * @param Bugsnag $bugsnagHelper
+     * @param Decider $featureSwitches
+     */
+    public function __construct(
+        Bugsnag $bugsnagHelper,
+        Decider $featureSwitches
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+        $this->featureSwitches = $featureSwitches;
+    }
+
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // Get result
+        $result = $observer->getResult();
+        // Get send classess
+        $sendClasses = $observer->getSendClasses();
+        list ($giftcardAccountFactory) = $sendClasses;
+        // Get extra arguments
+        $quote = $observer->getEvent()->getQuote();
+        $couponCode = $observer->getEvent()->getCouponCode();
+
+        if ($result !== null) {
+            return $result;
+        }
+        
+        try {
+            $giftcardAccount = $giftcardAccountFactory->create()->loadByCode($couponCode);
+            return $giftcardAccount->getAccountId() ? $giftcardAccount : $result;
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            return null;
+        } catch (\Exception $e) {
+            if ($this->featureSwitches->isReturnErrWhenRunFilter()) {
+                return $e;
+            } else {
+                $this->bugsnagHelper->notifyException($e);
+                return null;
+            }
+        }
+    }
+}

--- a/Observer/Amasty/GiftCard/RemoveAmastyGiftCardObserver.php
+++ b/Observer/Amasty/GiftCard/RemoveAmastyGiftCardObserver.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCard;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Discount;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class RemoveAmastyGiftCardObserver implements ObserverInterface
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * @var Discount
+     */
+    private $discountHelper;
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+    
+    /**
+     * constructor
+     *
+     * @param Bugsnag $bugsnagHelper
+     * @param Discount $discountHelper
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(
+        Bugsnag $bugsnagHelper,
+        Discount $discountHelper,
+        ResourceConnection $resourceConnection
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+        $this->discountHelper = $discountHelper;
+        $this->resourceConnection = $resourceConnection;
+    }
+    
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // Get extra arguments
+        $quote = $observer->getEvent()->getQuote();
+        $codeId = $observer->getEvent()->getCodeId();
+        
+        try {
+            $connection = $this->resourceConnection->getConnection();
+            $giftCardTable = $this->resourceConnection->getTableName('amasty_amgiftcard_quote');
+
+            $sql = "DELETE FROM {$giftCardTable} WHERE code_id = :code_id AND quote_id = :quote_id";
+            $connection->query($sql, ['code_id' => $codeId, 'quote_id' => $quote->getId()]);
+
+            $this->discountHelper->updateTotals($quote);
+        } catch (\Zend_Db_Statement_Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+        } catch (\Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+        }
+    }
+}

--- a/Observer/Amasty/GiftCard/ReplicateQuoteDataObserver.php
+++ b/Observer/Amasty/GiftCard/ReplicateQuoteDataObserver.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCard;
+
+use Bolt\ModulesSupport\Helper\Amasty\GiftCard as ModulesSupportHelper;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class ReplicateQuoteDataObserver implements ObserverInterface
+{
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // Get extra arguments
+        $source = $observer->getEvent()->getSource();
+        $destination = $observer->getEvent()->getDestination();
+
+        $this->modulesSupportHelper->replicateQuoteData($source, $destination);
+    }
+}

--- a/Observer/Amasty/GiftCardAccount/ApplyGiftcardObserver.php
+++ b/Observer/Amasty/GiftCardAccount/ApplyGiftcardObserver.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount;
+
+use Bolt\Boltpay\Model\ThirdParty\FilterInterface;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
+use Magento\Framework\Event\Observer;
+
+class ApplyGiftcardObserver implements FilterInterface
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * @var Bolt\Boltpay\Helper\FeatureSwitch\Decider
+     */
+    private $featureSwitches;
+
+    /**
+     * constructor
+     *
+     * @param Bugsnag $bugsnagHelper
+     * @param Decider $featureSwitches
+     */
+    public function __construct(
+        Bugsnag $bugsnagHelper,
+        Decider $featureSwitches
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+        $this->featureSwitches = $featureSwitches;
+    }
+
+    public function execute(Observer $observer)
+    {
+        // Get result
+        $result = $observer->getResult();
+        // Get send classes
+        $sendClasses = $observer->getSendClasses();
+        list ($giftcardProcessor) = $sendClasses;
+        // Get extra arguments
+        $code = $observer->getEvent()->getCode();
+        $giftCard = $observer->getEvent()->getGiftCard();
+        $immutableQuote = $observer->getEvent()->getImmutableQuote();
+        $parentQuote = $observer->getEvent()->getParentQuote();
+
+        if (!$giftCard instanceof \Amasty\GiftCardAccount\Api\Data\GiftCardAccountInterface) {
+            return $result;
+        }
+        try {
+            foreach ([$parentQuote, $immutableQuote] as $quote) {
+                $isGiftcardApplied = !empty(
+                    array_filter(
+                        $quote->getExtensionAttributes()->getAmGiftcardQuote()->getGiftCards(),
+                        function ($giftCardData) use ($giftCard) {
+                            return $giftCard->getAccountId() == $giftCardData['id'];
+                        }
+                    )
+                );
+                if ($isGiftcardApplied) {
+                    continue;
+                }
+                $giftcardProcessor->applyToCart($giftCard, $quote);
+            }
+
+            return [
+                'status'          => 'success',
+                'discount_code'   => $code,
+                'discount_amount' => abs(
+                    CurrencyUtils::toMinor($giftCard->getCurrentValue(), $parentQuote->getQuoteCurrencyCode())
+                ),
+                'description'     => __('Gift Card (%1)', $code),
+                'discount_type'   => 'fixed_amount',
+            ];
+        } catch (\Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+            return [
+                'status'        => 'failure',
+                'error_message' => $e->getMessage(),
+            ];
+        }
+    }
+}

--- a/Observer/Amasty/GiftCardAccount/BeforeFailedPaymentOrderSaveObserver.php
+++ b/Observer/Amasty/GiftCardAccount/BeforeFailedPaymentOrderSaveObserver.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class BeforeFailedPaymentOrderSaveObserver implements ObserverInterface
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * constructor
+     *
+     * @param Bugsnag $bugsnagHelper
+     */
+    public function __construct(
+        Bugsnag $bugsnagHelper
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+    }
+
+    public function execute(Observer $observer)
+    {
+        // Get send classes
+        $sendClasses = $observer->getSendClasses();
+        list ($giftcardRepository, $giftcardOrderRepository) = $sendClasses;
+        // Get extra arguments
+        $order = $observer->getEvent()->getOrder();
+
+        try {
+            $giftcardOrderExtension = $giftcardOrderRepository->getByOrderId($order->getId());
+            foreach ($giftcardOrderExtension->getGiftCards() as $orderGiftcard) {
+                try {
+                    /** @see GiftCardCartProcessor::GIFT_CARD_ID */
+                    $giftcard = $giftcardRepository->getById($orderGiftcard['id']);
+                    $giftcard->setCurrentValue(
+                        /** @see GiftCardCartProcessor::GIFT_CARD_BASE_AMOUNT */
+                        (float)($giftcard->getCurrentValue() + $orderGiftcard['b_amount'])
+                    );
+                    /** @see \Amasty\GiftCardAccount\Model\OptionSource\AccountStatus::STATUS_ACTIVE */
+                    $giftcard->setStatus(1);
+                    $giftcardRepository->save($giftcard);
+                } catch (\Magento\Framework\Exception\LocalizedException $e) {
+                    $this->bugsnagHelper->notifyException($e);
+                }
+            }
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            //no giftcards applied on order, safe to ignore
+        }
+    }
+}

--- a/Observer/Amasty/GiftCardAccount/ClearExternalDataObserver.php
+++ b/Observer/Amasty/GiftCardAccount/ClearExternalDataObserver.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class ClearExternalDataObserver implements ObserverInterface
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+    
+    /**
+     * constructor
+     *
+     * @param ResourceConnection $resourceConnection
+     * @param Bugsnag $bugsnagHelper
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        Bugsnag $bugsnagHelper
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+        $this->resourceConnection = $resourceConnection;
+    }
+    
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // Get extra arguments
+        $quote = $observer->getEvent()->getQuote();
+        
+        try {
+            $connection = $this->resourceConnection->getConnection();
+            $giftCardTable = $this->resourceConnection->getTableName('amasty_giftcard_quote');
+
+            $sql = "DELETE FROM {$giftCardTable} WHERE quote_id = :quote_id";
+            $bind = [
+                'quote_id' => $quote->getId()
+            ];
+
+            $connection->query($sql, $bind);
+        } catch (\Zend_Db_Statement_Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+        }
+    }
+}

--- a/Observer/Amasty/GiftCardAccount/CollectDiscountsObserver.php
+++ b/Observer/Amasty/GiftCardAccount/CollectDiscountsObserver.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount;
+
+use Bolt\Boltpay\Model\ThirdParty\FilterInterface;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\Discount;
+use Bolt\Boltpay\Helper\Shared\CurrencyUtils;
+use Magento\Framework\Event\Observer;
+
+class CollectDiscountsObserver implements FilterInterface
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * @var Discount
+     */
+    private $discountHelper;
+
+    /**
+     * constructor
+     *
+     * @param Bugsnag  $bugsnagHelper
+     * @param Discount  $discountHelper
+     */
+    public function __construct(
+        Bugsnag $bugsnagHelper,
+        Discount $discountHelper
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+        $this->discountHelper = $discountHelper;
+    }
+
+    public function execute(Observer $observer)
+    {
+        // Get result
+        $result = $observer->getResult();
+        // Get send classes
+        $sendClasses = $observer->getSendClasses();
+        list ($giftcardAccountRepository, $giftcardQuoteRepository) = $sendClasses;
+        // Get extra arguments
+        $quote = $observer->getEvent()->getQuote();
+        $parentQuote = $observer->getEvent()->getParentQuote();
+        $paymentOnly = $observer->getEvent()->getPaymentOnly();
+       
+        list ($discounts, $totalAmount, $diff) = $result;
+        try {
+            $currencyCode = $quote->getQuoteCurrencyCode();
+            /** @var \Magento\Quote\Model\Quote\Address\Total[] */
+            $totals = $quote->getTotals();
+            $totalDiscount = $totals[Discount::AMASTY_GIFTCARD] ?? null;
+            $roundedDiscountAmount = 0;
+            $discountAmount = 0;
+            ///////////////////////////////////////////////////////////////////////////
+            // If Amasty gift cards can be used for shipping and tax (PayForEverything)
+            // accumulate all the applied gift cards balance as discount amount. If the
+            // final discounts sum is greater than the cart total amount ($totalAmount < 0)
+            // the "fixed_amount" type is added below.
+            ///////////////////////////////////////////////////////////////////////////
+            if ($totalDiscount && $totalDiscount->getValue() && $this->discountHelper->getAmastyPayForEverything()) {
+                $giftcardQuote = $giftcardQuoteRepository->getByQuoteId($quote->getId());
+                $discountType = $this->discountHelper->getBoltDiscountType('by_fixed');
+                foreach ($giftcardQuote->getGiftCards() as $appliedGiftcardData) {
+                    $giftcard = $giftcardAccountRepository->getById($appliedGiftcardData['id']);
+                    $amount = abs($giftcard->getCurrentValue());
+                    $roundedAmount = CurrencyUtils::toMinor($amount, $currencyCode);
+                    $giftCardCode = $giftcard->getCodeModel()->getCode();
+                    $discountItem = [
+                        'description'       => __('Gift Card ') . $giftCardCode,
+                        'amount'            => $roundedAmount,
+                        'discount_category' => Discount::BOLT_DISCOUNT_CATEGORY_GIFTCARD,
+                        'reference'         => $giftCardCode,
+                        'discount_type'     => $discountType,
+                        // For v1/discounts.code.apply and v2/cart.update
+                        'type'              => $discountType,
+                        // For v1/merchant/order
+                    ];
+                    $discountAmount += $amount;
+                    $roundedDiscountAmount += $roundedAmount;
+                    $discounts[] = $discountItem;
+                }
+
+                $diff -= CurrencyUtils::toMinorWithoutRounding($discountAmount, $currencyCode) - $roundedDiscountAmount;
+                $totalAmount -= $roundedDiscountAmount;
+            }
+        } catch (\Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+        } finally {
+            return [$discounts, $totalAmount, $diff];
+        }
+    }
+}

--- a/Observer/Amasty/GiftCardAccount/DeleteRedundantDiscountsObserver.php
+++ b/Observer/Amasty/GiftCardAccount/DeleteRedundantDiscountsObserver.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class DeleteRedundantDiscountsObserver implements ObserverInterface
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+    
+    /**
+     * constructor
+     *
+     * @param ResourceConnection  $resourceConnection
+     * @param Bugsnag  $bugsnagHelper
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        Bugsnag $bugsnagHelper
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+        $this->resourceConnection = $resourceConnection;
+    }
+    
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // Get extra arguments
+        $parentQuote = $observer->getEvent()->getParentQuote();
+        
+        try {
+            $connection = $this->resourceConnection->getConnection();
+            $giftCardTable = $this->resourceConnection->getTableName('amasty_giftcard_quote');
+            $quoteTable = $this->resourceConnection->getTableName('quote');
+
+            $sql = "DELETE FROM {$giftCardTable} WHERE quote_id IN 
+                    (SELECT entity_id FROM {$quoteTable} 
+                    WHERE bolt_parent_quote_id = :bolt_parent_quote_id AND entity_id != :entity_id)";
+            
+            $bind = [
+                'bolt_parent_quote_id' => $parentQuote->getBoltParentQuoteId(),
+                'entity_id' => $parentQuote->getBoltParentQuoteId()
+            ];
+
+            $connection->query($sql, $bind);
+        } catch (\Zend_Db_Statement_Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+        }
+    }
+}

--- a/Observer/Amasty/GiftCardAccount/FilterApplyingGiftCardCodeObserver.php
+++ b/Observer/Amasty/GiftCardAccount/FilterApplyingGiftCardCodeObserver.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount;
+
+use Bolt\Boltpay\Model\ThirdParty\FilterInterface;
+use Magento\Framework\Event\Observer;
+
+class FilterApplyingGiftCardCodeObserver implements FilterInterface
+{
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // Get result
+        $result = $observer->getResult();
+        // Get send classes
+        $sendClasses = $observer->getSendClasses();
+        list ($giftcardProcessor) = $sendClasses;
+        // Get extra arguments
+        $giftCard = $observer->getEvent()->getGiftCard();
+        $quote = $observer->getEvent()->getQuote();
+
+        if (!$giftCard instanceof \Amasty\GiftCardAccount\Api\Data\GiftCardAccountInterface) {
+            return $result;
+        }
+        try {
+            $giftcardProcessor->applyToCart($giftCard, $quote);
+            $result = true;
+        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            //no giftcards applied on order, safe to ignore
+        }
+        
+        return $result;
+    }
+}

--- a/Observer/Amasty/GiftCardAccount/FilterRemovingGiftCardCodeObserver.php
+++ b/Observer/Amasty/GiftCardAccount/FilterRemovingGiftCardCodeObserver.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount;
+
+use Bolt\Boltpay\Model\ThirdParty\FilterInterface;
+use Magento\Framework\Event\Observer;
+
+class FilterRemovingGiftCardCodeObserver implements FilterInterface
+{
+    public function execute(Observer $observer)
+    {
+        // Get result
+        $result = $observer->getResult();
+        // Get send classess
+        $sendClasses = $observer->getSendClasses();
+        list ($giftcardProcessor) = $sendClasses;
+        // Get extra arguments
+        $giftCard = $observer->getEvent()->getGiftCard();
+        $quote = $observer->getEvent()->getQuote();
+
+        if (!$giftCard instanceof \Amasty\GiftCardAccount\Api\Data\GiftCardAccountInterface) {
+            return $result;
+        }
+        try {
+            $giftcardProcessor->removeFromCart($giftCard, $quote);
+            $result = true;
+        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            //no giftcards applied on order, safe to ignore
+        }
+        
+        return $result;
+    }
+}

--- a/Observer/Amasty/GiftCardAccount/LoadGiftcardObserver.php
+++ b/Observer/Amasty/GiftCardAccount/LoadGiftcardObserver.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount;
+
+use Bolt\Boltpay\Model\ThirdParty\FilterInterface;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Helper\FeatureSwitch\Decider;
+use Magento\Framework\Event\Observer;
+
+class LoadGiftcardObserver implements FilterInterface
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * @var Bolt\Boltpay\Helper\FeatureSwitch\Decider
+     */
+    private $featureSwitches;
+    
+    /**
+     * constructor
+     *
+     * @param Bugsnag  $bugsnagHelper
+     * @param Decider $featureSwitches
+     */
+    public function __construct(
+        Bugsnag $bugsnagHelper,
+        Decider $featureSwitches
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+        $this->featureSwitches = $featureSwitches;
+    }
+
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // Get result
+        $result = $observer->getResult();
+        // Get send classess
+        $sendClasses = $observer->getSendClasses();
+        list ($giftcardAccountRepository) = $sendClasses;
+        // Get extra arguments
+        $couponCode = $observer->getEvent()->getCouponCode();
+
+        if ($result !== null) {
+            return $result;
+        }
+        
+        try {
+            return $giftcardAccountRepository->getByCode($couponCode);
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            return null;
+        } catch (\Exception $e) {
+            if ($this->featureSwitches->isReturnErrWhenRunFilter()) {
+                return $e;
+            } else {
+                $this->bugsnagHelper->notifyException($e);
+                return null;
+            }
+        }
+    }
+}

--- a/Observer/Amasty/GiftCardAccount/RemoveAmastyGiftCardObserver.php
+++ b/Observer/Amasty/GiftCardAccount/RemoveAmastyGiftCardObserver.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class RemoveAmastyGiftCardObserver implements ObserverInterface
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * constructor
+     *
+     * @param Bugsnag  $bugsnagHelper
+     */
+    public function __construct(
+        Bugsnag $bugsnagHelper
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+    }
+
+    public function execute(Observer $observer)
+    {
+        $sendClasses = $observer->getSendClasses();
+        list ($amastyGiftCardAccountManagement) = $sendClasses;
+        $quote = $observer->getEvent()->getQuote();
+        $codeId = $observer->getEvent()->getCodeId();
+        
+        try {
+            if ($quote->getExtensionAttributes() && $quote->getExtensionAttributes()->getAmGiftcardQuote()) {
+                $cards = $quote->getExtensionAttributes()->getAmGiftcardQuote()->getGiftCards();
+            }
+
+            $giftCodeExists = false;
+            $giftCode = '';
+            foreach ($cards as $k => $card) {
+                if ($card['id'] == $codeId) {
+                    $giftCodeExists = true;
+                    $giftCode = $card['code'];
+                    break;
+                }
+            }
+            
+            if ($giftCodeExists) {
+                $amastyGiftCardAccountManagement->removeGiftCardFromCart($quote->getId(), $giftCode);
+            }
+        } catch (\Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+        }
+    }
+}

--- a/Observer/Amasty/GiftCardAccount/ReplicateQuoteDataObserver.php
+++ b/Observer/Amasty/GiftCardAccount/ReplicateQuoteDataObserver.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ *
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount;
+
+use Bolt\Boltpay\Helper\Bugsnag;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class ReplicateQuoteDataObserver implements ObserverInterface
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+    
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+    
+    /**
+     * constructor
+     *
+     * @param ResourceConnection  $resourceConnection
+     * @param Bugsnag  $bugsnagHelper
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        Bugsnag $bugsnagHelper
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->bugsnagHelper = $bugsnagHelper;
+    }
+
+    /**
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        // Get extra arguments
+        $source = $observer->getEvent()->getSource();
+        $destination = $observer->getEvent()->getDestination();
+
+        try {
+            if ($source->getId() == $destination->getId()) {
+                return;
+            }
+            $connection = $this->resourceConnection->getConnection();
+            $connection->beginTransaction();
+            $giftCardTable = $this->resourceConnection->getTableName('amasty_giftcard_quote');
+            // Clear previously applied gift cart codes from the immutable quote
+            $sql = "DELETE FROM {$giftCardTable} WHERE quote_id = :destination_quote_id";
+            $connection->query($sql, ['destination_quote_id' => $destination->getId()]);
+    
+            // Copy all gift cart codes applied to the parent quote to the immutable quote
+            $sql = "INSERT INTO {$giftCardTable} (quote_id, gift_cards, gift_amount, base_gift_amount, gift_amount_used, base_gift_amount_used)
+                            SELECT :destination_quote_id, gift_cards, gift_amount, base_gift_amount, gift_amount_used, base_gift_amount_used
+                            FROM {$giftCardTable} WHERE quote_id = :source_quote_id";
+    
+            $connection->query(
+                $sql,
+                ['destination_quote_id' => $destination->getId(), 'source_quote_id' => $source->getId()]
+            );
+    
+            $connection->commit();   
+        } catch (\Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+        }
+    }
+}

--- a/Plugin/Amasty/GiftCard/AmastyGiftCardRemovePlugin.php
+++ b/Plugin/Amasty/GiftCard/AmastyGiftCardRemovePlugin.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_ModulesSupport
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Bolt\ModulesSupport\Plugin\Amasty\GiftCard;
+
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Controller\ResultInterface;
+use Bolt\Boltpay\Helper\Bugsnag;
+use Bolt\Boltpay\Model\EventsForThirdPartyModules;
+
+/**
+ * Class AmastyGiftCardRemovePlugin
+ * Ensure Gift Card is removed from the parent quote.
+ * The default method removes the first found row which might corespond to some previusly created immutable quote.
+ */
+class AmastyGiftCardRemovePlugin
+{
+    /**
+     * @var Bugsnag
+     */
+    private $bugsnagHelper;
+
+    /**
+     * @var EventsForThirdPartyModules
+     */
+    private $eventsForThirdPartyModules;
+
+    /**
+     * AmastyGiftCardRemovePlugin constructor.
+     * @param Bugsnag   $bugsnagHelper
+     * @param EventsForThirdPartyModules   $eventsForThirdPartyModules
+     */
+    public function __construct(
+        Bugsnag $bugsnagHelper,
+        EventsForThirdPartyModules $eventsForThirdPartyModules
+    ) {
+        $this->bugsnagHelper = $bugsnagHelper;
+        $this->eventsForThirdPartyModules = $eventsForThirdPartyModules;
+    }
+
+    /**
+     * Remove Amasty Gift Card from the (parent) quote
+     *
+     * @param Action $subject the observed object
+     * @param ResponseInterface|ResultInterface|void $result the result of the observed method call
+     * @return ResponseInterface|ResultInterface|void
+     */
+    public function afterExecute(Action $subject, $result)
+    {
+        try {
+            // Get the code id from the original request
+            $codeId = $subject->getRequest()->getParam('code_id');
+    
+            // Access protected checkoutSession property with a Closure proxy
+            $getQuoteProxy = function () use ($subject) {
+                return $subject->checkoutSession->create()->getQuote();
+            };
+            $quote = $getQuoteProxy->call($subject);
+    
+            // Remove Amasty Gift Cart from the parent (session) quote
+            $this->eventsForThirdPartyModules->dispatch(
+                "remove_amasty_giftcard",
+                [
+                    'code_id' => $codeId,
+                    'quote' => $quote,
+                ]
+            );
+    
+            // Access protected updateTotalsInQuote method with a Closure proxy
+            $updateTotalsInQuoteProxy = function () use ($subject, $quote) {
+                $subject->updateTotalsInQuote($quote);
+            };
+            $updateTotalsInQuoteProxy->call($subject);
+        } catch (\Exception $e) {
+            $this->bugsnagHelper->notifyException($e);
+        } finally {
+            return $result;
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "boltpay/bolt-magento2-modules-support",
+    "description": "Bolt payment gateway magento2 modules support",
+    "require": {
+        "boltpay/bolt-magento2": "^2.22",
+    },
+    "type": "magento2-module",
+    "version": "1.0.0",
+    "license": "MIT",
+    "autoload": {
+        "files": [ "registration.php" ],
+        "psr-4": {
+            "Bolt\\ModulesSupport\\": ""
+        }
+    },
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://repo.magento.com/"
+        }
+    ]
+}

--- a/etc/bolt_events.xml
+++ b/etc/bolt_events.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <!-- Amasty_GiftCardAccount -->
+    <event name="before_failed_payment_order_save">
+        <observer name="Bolt_Amasty_GiftCardAccount_Event_BeforeFailedPaymentOrderSave"
+                  module="Amasty_GiftCardAccount"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount\BeforeFailedPaymentOrderSaveObserver">
+            <send_class instance="Amasty\GiftCardAccount\Model\GiftCardAccount\Repository" />
+            <send_class instance="Amasty\GiftCardAccount\Model\GiftCardExtension\Order\Repository" />
+        </observer>
+    </event>
+    <event name="replicate_quote_data">
+        <observer name="Bolt_Amasty_GiftCardAccount_Event_ReplicateQuoteData"
+                  module="Amasty_GiftCardAccount"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount\ReplicateQuoteDataObserver">
+        </observer>
+    </event>
+    <event name="clear_external_data">
+        <observer name="Bolt_Amasty_GiftCardAccount_Event_ClearExternalData"
+                  module="Amasty_GiftCardAccount"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount\ClearExternalDataObserver">
+        </observer>
+    </event>
+    <event name="delete_redundant_discounts">
+        <observer name="Bolt_Amasty_GiftCardAccount_Event_DeleteRedundantDiscounts"
+                  module="Amasty_GiftCardAccount"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount\DeleteRedundantDiscountsObserver">
+        </observer>
+    </event>
+    <event name="remove_amasty_giftcard">
+        <observer name="Bolt_Amasty_GiftCardAccount_Event_RemoveAmastyGiftCard"
+                  module="Amasty_GiftCardAccount"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount\RemoveAmastyGiftCardObserver">
+            <send_class instance="Amasty\GiftCardAccount\Model\GiftCardAccount\GiftCardAccountManagement" />
+        </observer>
+    </event>
+    <filter name="collect_discounts">
+        <observer name="Bolt_Amasty_GiftCardAccount_Filter_CollectDiscounts"
+                  module="Amasty_GiftCardAccount"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount\CollectDiscountsObserver">
+            <send_class instance="Amasty\GiftCardAccount\Api\GiftCardAccountRepositoryInterface" />
+            <send_class instance="Amasty\GiftCardAccount\Api\GiftCardQuoteRepositoryInterface" />
+        </observer>
+    </filter>
+    <filter name="load_giftcard">
+        <observer name="Bolt_Amasty_GiftCardAccount_Filter_LoadGiftcard"
+                  module="Amasty_GiftCardAccount"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount\LoadGiftcardObserver">
+            <send_class instance="Amasty\GiftCardAccount\Api\GiftCardAccountRepositoryInterface" />
+        </observer>
+    </filter>
+    <filter name="apply_giftcard">
+        <observer name="Bolt_Amasty_GiftCardAccount_Filter_ApplyGiftcard"
+                  module="Amasty_GiftCardAccount"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount\ApplyGiftcardObserver">
+            <send_class instance="Amasty\GiftCardAccount\Model\GiftCardAccount\GiftCardCartProcessor" />
+        </observer>
+    </filter>
+    <filter name="filter_applying_giftcard_code">
+        <observer name="Bolt_Amasty_GiftCardAccount_Filter_FilterApplyingGiftCardCode"
+                  module="Amasty_GiftCardAccount"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount\FilterApplyingGiftCardCodeObserver">
+            <send_class instance="Amasty\GiftCardAccount\Model\GiftCardAccount\GiftCardCartProcessor" />
+        </observer>
+    </filter>
+    <filter name="filter_removing_giftcard_code">
+        <observer name="Bolt_Amasty_GiftCardAccount_Filter_FilterRemovingGiftCardCode"
+                  module="Amasty_GiftCardAccount"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount\FilterRemovingGiftCardCodeObserver">
+            <send_class instance="Amasty\GiftCardAccount\Model\GiftCardAccount\GiftCardCartProcessor" />
+        </observer>
+    </filter>
+    <!-- Amasty_GiftCardAccount -->
+    
+    <!-- Amasty_GiftCard -->
+    <event name="before_failed_payment_order_save">
+        <observer name="Bolt_Amasty_GiftCard_Event_BeforeFailedPaymentOrderSave"
+                  module="Amasty_GiftCard"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCard\BeforeFailedPaymentOrderSaveObserver">
+            <check_class instance="Amasty\GiftCard\Model\GiftCardManagement" />
+            <check_class instance="Amasty\GiftCard\Model\AccountFactory" />
+            <check_class instance="Amasty\GiftCard\Model\ResourceModel\Quote\CollectionFactory" />
+            <check_class instance="Amasty\GiftCard\Api\CodeRepositoryInterface" />
+            <check_class instance="Amasty\GiftCard\Api\AccountRepositoryInterface" />
+            <send_class instance="Amasty\GiftCard\Model\ResourceModel\Quote\CollectionFactory" />
+            <send_class instance="Amasty\GiftCard\Api\CodeRepositoryInterface" />
+            <send_class instance="Amasty\GiftCard\Api\AccountRepositoryInterface" />
+        </observer>
+    </event>
+    <event name="replicate_quote_data">
+        <observer name="Bolt_Amasty_GiftCard_Event_ReplicateQuoteData"
+                  module="Amasty_GiftCard"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCard\ReplicateQuoteDataObserver">
+            <check_class instance="Amasty\GiftCard\Model\GiftCardManagement" />
+            <check_class instance="Amasty\GiftCard\Model\AccountFactory" />
+            <check_class instance="Amasty\GiftCard\Model\ResourceModel\Quote\CollectionFactory" />
+            <check_class instance="Amasty\GiftCard\Api\CodeRepositoryInterface" />
+            <check_class instance="Amasty\GiftCard\Api\AccountRepositoryInterface" />
+        </observer>
+    </event>
+    <event name="clear_external_data">
+        <observer name="Bolt_Amasty_GiftCard_Event_ClearExternalData"
+                  module="Amasty_GiftCard"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCard\ClearExternalDataObserver">
+            <check_class instance="Amasty\GiftCard\Model\GiftCardManagement" />
+            <check_class instance="Amasty\GiftCard\Model\AccountFactory" />
+            <check_class instance="Amasty\GiftCard\Model\ResourceModel\Quote\CollectionFactory" />
+            <check_class instance="Amasty\GiftCard\Api\CodeRepositoryInterface" />
+            <check_class instance="Amasty\GiftCard\Api\AccountRepositoryInterface" />
+        </observer>
+    </event>
+    <event name="delete_redundant_discounts">
+        <observer name="Bolt_Amasty_GiftCard_Event_DeleteRedundantDiscounts"
+                  module="Amasty_GiftCard"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCard\DeleteRedundantDiscountsObserver">
+            <check_class instance="Amasty\GiftCard\Model\GiftCardManagement" />
+            <check_class instance="Amasty\GiftCard\Model\AccountFactory" />
+            <check_class instance="Amasty\GiftCard\Model\ResourceModel\Quote\CollectionFactory" />
+            <check_class instance="Amasty\GiftCard\Api\CodeRepositoryInterface" />
+            <check_class instance="Amasty\GiftCard\Api\AccountRepositoryInterface" />
+        </observer>
+    </event>
+    <event name="remove_amasty_giftcard">
+        <observer name="Bolt_Amasty_GiftCard_Event_RemoveAmastyGiftCard"
+                  module="Amasty_GiftCard"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCard\RemoveAmastyGiftCardObserver">
+            <check_class instance="Amasty\GiftCard\Model\GiftCardManagement" />
+            <check_class instance="Amasty\GiftCard\Model\AccountFactory" />
+            <check_class instance="Amasty\GiftCard\Model\ResourceModel\Quote\CollectionFactory" />
+            <check_class instance="Amasty\GiftCard\Api\CodeRepositoryInterface" />
+            <check_class instance="Amasty\GiftCard\Api\AccountRepositoryInterface" />
+        </observer>
+    </event>
+    <filter name="collect_discounts">
+        <observer name="Bolt_Amasty_GiftCard_Filter_CollectDiscounts"
+                  module="Amasty_GiftCard"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCard\CollectDiscountsObserver">
+            <check_class instance="Amasty\GiftCard\Model\GiftCardManagement" />
+            <check_class instance="Amasty\GiftCard\Model\AccountFactory" />
+            <check_class instance="Amasty\GiftCard\Model\ResourceModel\Quote\CollectionFactory" />
+            <check_class instance="Amasty\GiftCard\Api\CodeRepositoryInterface" />
+            <check_class instance="Amasty\GiftCard\Api\AccountRepositoryInterface" />
+            <send_class instance="Amasty\GiftCard\Model\ResourceModel\Quote\CollectionFactory" />
+        </observer>
+    </filter>
+    <filter name="load_giftcard">
+        <observer name="Bolt_Amasty_GiftCard_Filter_LoadGiftcard"
+                  module="Amasty_GiftCard"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCard\LoadGiftcardObserver">
+            <check_class instance="Amasty\GiftCard\Model\GiftCardManagement" />
+            <check_class instance="Amasty\GiftCard\Model\AccountFactory" />
+            <check_class instance="Amasty\GiftCard\Model\ResourceModel\Quote\CollectionFactory" />
+            <check_class instance="Amasty\GiftCard\Api\CodeRepositoryInterface" />
+            <check_class instance="Amasty\GiftCard\Api\AccountRepositoryInterface" />
+            <send_class instance="Amasty\GiftCard\Model\AccountFactory" />
+        </observer>
+    </filter>
+    <filter name="apply_giftcard">
+        <observer name="Bolt_Amasty_GiftCard_Filter_ApplyGiftcard"
+                  module="Amasty_GiftCard"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCard\ApplyGiftcardObserver">
+            <check_class instance="Amasty\GiftCard\Model\GiftCardManagement" />
+            <check_class instance="Amasty\GiftCard\Model\AccountFactory" />
+            <check_class instance="Amasty\GiftCard\Model\ResourceModel\Quote\CollectionFactory" />
+            <check_class instance="Amasty\GiftCard\Api\CodeRepositoryInterface" />
+            <check_class instance="Amasty\GiftCard\Api\AccountRepositoryInterface" />
+            <send_class instance="Amasty\GiftCard\Model\GiftCardManagementFactory" />
+        </observer>
+    </filter>
+    <filter name="filter_applying_giftcard_code">
+        <observer name="Bolt_Amasty_GiftCard_Filter_FilterApplyingGiftCardCode"
+                  module="Amasty_GiftCard"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCard\FilterApplyingGiftCardCodeObserver">
+            <check_class instance="Amasty\GiftCard\Model\GiftCardManagement" />
+            <check_class instance="Amasty\GiftCard\Model\AccountFactory" />
+            <check_class instance="Amasty\GiftCard\Model\ResourceModel\Quote\CollectionFactory" />
+            <check_class instance="Amasty\GiftCard\Api\CodeRepositoryInterface" />
+            <check_class instance="Amasty\GiftCard\Api\AccountRepositoryInterface" />
+            <send_class instance="Amasty\GiftCard\Model\GiftCardManagement" />
+        </observer>
+    </filter>
+    <filter name="filter_removing_giftcard_code">
+        <observer name="Bolt_Amasty_GiftCard_Filter_FilterRemovingGiftCardCode"
+                  module="Amasty_GiftCard"
+                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCard\FilterRemovingGiftCardCodeObserver">
+            <check_class instance="Amasty\GiftCard\Model\GiftCardManagement" />
+            <check_class instance="Amasty\GiftCard\Model\AccountFactory" />
+            <check_class instance="Amasty\GiftCard\Model\ResourceModel\Quote\CollectionFactory" />
+            <check_class instance="Amasty\GiftCard\Api\CodeRepositoryInterface" />
+            <check_class instance="Amasty\GiftCard\Api\AccountRepositoryInterface" />
+            <send_class instance="Amasty\GiftCard\Model\GiftCardManagement" />
+        </observer>
+    </filter>
+    <!-- Amasty_GiftCard -->
+    
+</config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+
+</config>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+-->
+<!-- Bolt Frontend Dependency Injection Configuration -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Amasty\GiftCard\Controller\Cart\Remove">
+        <plugin name="Bolt_Amasty_GiftCard_Remove_Plugin" type="Bolt\ModulesSupport\Plugin\Amasty\GiftCard\AmastyGiftCardRemovePlugin" sortOrder="1" />
+    </type>
+</config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Bolt_ModulesSupport" setup_version="1.0.0">
+        <sequence>
+            <module name="Bolt_Boltpay"/>
+        </sequence>
+    </module>
+</config>

--- a/registration.php
+++ b/registration.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Bolt magento2 plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Modules_Support
+ * @copyright  Copyright (c) 2017-2021 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
+    'Bolt_ModulesSupport',
+    __DIR__
+);


### PR DESCRIPTION
In general, we have two types of hooks, event and filter,

- an event takes the info it receives, does something with it, and returns nothing. In other words: it acts on something and then exits, returning nothing back to the calling hook.

- a filter takes the info it receives, modifies it somehow, and returns it. In other words: it filters something and passes it back to the hook for further use.

To subscribe a callback(observer) to a hook in the Bolt plugin for a specific action or filter, we make the custom event/filter subscribable by declaring the etc/bolt_events.xml file, then the Bolt plugin would read its content and associate callback(observer) with event/filter.

Observers can be configured to watch certain events/filters in the bolt_events.xml file. There are two types of nodes under config :<event> for event and <filter> for filter

The structure of event node

```
<!-- The name of the observer for the event definition -->
<event name="before_failed_payment_order_save">
        <!-- The name of the observer for the event definition -->
        <observer name="Bolt_Amasty_GiftCardAccount_Event_BeforeFailedPaymentOrderSave"
                 <!-- The name of 3p module -->
                  module="Amasty_GiftCardAccount"
                 <!-- The fully qualified class name of the observer. -->
                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount\BeforeFailedPaymentOrderSaveObserver">
            <!-- The fully qualified class name for creating instance and sending to observer as argument. -->
            <send_class instance="Amasty\GiftCardAccount\Model\GiftCardAccount\Repository" />
            <!-- The fully qualified class name for checking whether neccessary classes exist. -->
            <check_class instance="Amasty\GiftCardAccount\Model\GiftCardExtension\Order\Repository" />
        </observer>
</event>
```

The structure of filter node

```
<!-- The name of the observer for the event definition -->
<filter name="before_failed_payment_order_save">
        <!-- The name of the observer for the event definition -->
        <observer name="Bolt_Amasty_GiftCardAccount_Event_BeforeFailedPaymentOrderSave"
                 <!-- The name of 3p module -->
                  module="Amasty_GiftCardAccount"
                 <!-- The fully qualified class name of the observer. -->
                  instance="Bolt\ModulesSupport\Observer\Amasty\GiftCardAccount\BeforeFailedPaymentOrderSaveObserver">
            <!-- The fully qualified class name for creating instance and sending to observer as argument. -->
            <send_class instance="Amasty\GiftCardAccount\Model\GiftCardAccount\Repository" />
            <!-- The fully qualified class name for checking whether neccessary classes exist. -->
            <check_class instance="Amasty\GiftCardAccount\Model\GiftCardExtension\Order\Repository" />
        </observer>
</filter>
```

The how to get the related data in observer 

```
// Get result (for filter only)
$result = $observer->getResult();
// Get send classess
$sendClasses = $observer->getSendClasses();
list ($giftcardAccountFactory) = $sendClasses;
// Get extra arguments
$quote = $observer->getEvent()->getQuote();
$couponCode = $observer->getEvent()->getCouponCode();
```

For now this PR is to show how to move supports for Amasty Giftcard to magento2-modules-support, we will continue to work on code for other 3p modules